### PR TITLE
Add Pylint plugin for verboselogs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ NOTSET    0              When a logger is created, the level is set to NOTSET
                          (note that the root logger is created with level
                          WARNING). **In practice this level is never explicitly
                          used; it's mentioned here only for completeness.**
-SPAM      5              **Way to verbose for regular debugging, but nice to
+SPAM      5              **Way too verbose for regular debugging, but nice to
                          have when someone is getting desperate in a late night
                          debugging session and decides that they want as much
                          instrumentation as possible! :-)**
@@ -106,10 +106,34 @@ and configurable logging::
    # Your code goes here.
    ...
 
+If you want to set ``verboselogs.VerboseLogger`` as the default logging class
+for all subsequent logger instances, you can do so::
+
+   import logging
+   import verboselogs
+
+   logging.setLoggerClass(verboselogs.VerboseLogger)
+   logger = logging.getLogger(__name__) # will be a VerboseLogger instance
+
+
+PyLint plugin
+-------------
+If using the above ``logging.setLoggerClass`` approach, `Pylint`_ is not
+smart enough to recognize that ``logging`` is using ``verboselogs``, resulting
+in errors like::
+
+   E:285,24: Module 'logging' has no 'VERBOSE' member (no-member)
+   E:375,12: Instance of 'RootLogger' has no 'verbose' member (no-member)
+
+To fix this, ``verboselogs`` provides a Pylint plugin ``verboselogs_pylint``
+which, when loaded with ``pylint --load-plugins verboselogs_pylint``, adds
+the ``verboselogs`` methods and constants to Pylint's understanding of the
+``logging`` module.
+
 Contact
 -------
 
-The latest version of `verboselogs` is available on PyPI_ and GitHub_. For bug
+The latest version of ``verboselogs`` is available on PyPI_ and GitHub_. For bug
 reports please create an issue on GitHub_. If you have questions, suggestions,
 etc. feel free to send me an e-mail at `peter@peterodding.com`_.
 
@@ -124,6 +148,7 @@ This software is licensed under the `MIT license`_.
 .. _GitHub: https://github.com/xolox/python-verboselogs
 .. _MIT license: http://en.wikipedia.org/wiki/MIT_License
 .. _peter@peterodding.com: peter@peterodding.com
+.. _Pylint: https://pypi.python.org/pypi/pylint
 .. _PyPI: https://pypi.python.org/pypi/verboselogs
 .. _logging.Logger: http://docs.python.org/2/library/logging.html#logger-objects
 .. _numeric values: http://docs.python.org/2/howto/logging.html#logging-levels

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     url='https://github.com/xolox/python-verboselogs',
     author='Peter Odding',
     author_email='peter@peterodding.com',
-    py_modules=['verboselogs'],
+    py_modules=['verboselogs', 'verboselogs_pylint'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/verboselogs_pylint.py
+++ b/verboselogs_pylint.py
@@ -1,0 +1,32 @@
+"""
+Pylint plugin to fix invalid errors about the logging module.
+
+Author: Glenn Matthews <glenn@e-dad.net>
+Last Change: June 22, 2016
+URL: https://pypi.python.org/pypi/verboselogs
+"""
+
+from astroid import MANAGER, scoped_nodes, nodes
+
+
+def register(linter):
+    """No-op (required by Pylint)."""
+    pass
+
+
+def verboselogs_class_transform(cls):
+    """Make Pylint aware of RootLogger.verbose and RootLogger.spam."""
+    if cls.name == 'RootLogger':
+        for meth in ['verbose', 'spam']:
+            cls.locals[meth] = [scoped_nodes.Function(meth, None)]
+
+
+def verboselogs_module_transform(mod):
+    """Make Pylint aware of logging.VERBOSE and logging.SPAM."""
+    if mod.name == 'logging':
+        for const in ['VERBOSE', 'SPAM']:
+            mod.locals[const] = [nodes.Const(const)]
+
+# Register the above methods with Pylint.
+MANAGER.register_transform(scoped_nodes.Class, verboselogs_class_transform)
+MANAGER.register_transform(scoped_nodes.Module, verboselogs_module_transform)


### PR DESCRIPTION
In my project [COT](https://github.com/glennmatthews/cot) I am using verboselogs extensively (via `logging.setLoggerClass(VerboseLogger)`). I recently started running [pylint](https://pypi.python.org/pypi/pylint) to see what it catches differently from flake8, and got a lot of warnings due to pylint not recognizing that logging is using verboselogs. I've implemented a simple pylint plugin that fixes this, and rather than making it a separate package, it seemed appropriate to just add it to verboselogs itself.

Thanks for verboselogs!
