### PR TITLE
Proper funcName settings

### DIFF
--- a/verboselogs/__init__.py
+++ b/verboselogs/__init__.py
@@ -125,14 +125,17 @@ class VerboseLogger(logging.Logger):
         logging.Logger.__init__(self, *args, **kw)
         self.parent = logging.getLogger()
 
-    def notice(self, *args, **kw):
+    def notice(self, msg, *args, **kw):
         """Log a message with level :data:`NOTICE`. The arguments are interpreted as for :func:`logging.debug()`."""
-        self.log(NOTICE, *args, **kw)
+        if self.isEnabledFor(NOTICE):
+            self._log(NOTICE, msg, args, **kw)
 
-    def verbose(self, *args, **kw):
+    def verbose(self, msg, *args, **kw):
         """Log a message with level :data:`VERBOSE`. The arguments are interpreted as for :func:`logging.debug()`."""
-        self.log(VERBOSE, *args, **kw)
+        if self.isEnabledFor(VERBOSE):
+            self._log(VERBOSE, msg, args, **kw)
 
-    def spam(self, *args, **kw):
+    def spam(self, msg, *args, **kw):
         """Log a message with level :data:`SPAM`. The arguments are interpreted as for :func:`logging.debug()`."""
-        self.log(SPAM, *args, **kw)
+        if self.isEnabledFor(SPAM):
+            self._log(SPAM, msg, args, **kw)

--- a/verboselogs/tests.py
+++ b/verboselogs/tests.py
@@ -47,12 +47,12 @@ class VerboseLogsTestCase(unittest.TestCase):
         """
         for name in 'notice', 'verbose', 'spam':
             logger = verboselogs.VerboseLogger(random_string())
-            logger.log = mock.MagicMock()
+            logger._log = mock.MagicMock()
             level = getattr(verboselogs, name.upper())
             method = getattr(logger, name.lower())
             message = "Any random message"
             method(message)
-            logger.log.assert_called_with(level, message)
+            logger._log.assert_called_with(level, message, ())
 
     def test_pylint_plugin(self):
         """Test the :mod:`verboselogs.pylint` module."""


### PR DESCRIPTION
Call `_log` instead of `log` so as to have same stack depth as built-in logging functions, resulting in correct setting of `funcName` in log records. Fixes #5.

Example:

```
 VERBOSE: generate_manifest      Generating manifest for /var/folders/jz/mz212x091v13dtpylgsvrc500000gn/T/cotrnhn07r5/temp.ovf
 VERBOSE: tar                    Creating tar file temp.ova
 VERBOSE: tar                    Adding /var/folders/jz/mz212x091v13dtpylgsvrc500000gn/T/cotrnhn07r5/temp.ovf to temp.ova
 VERBOSE: tar                    Adding manifest to temp.ova
    INFO: add_to_archive         Adding COT/tests/input.vmdk to TAR file as input.vmdk
 VERBOSE: tar                    Added input.vmdk to temp.ova
    INFO: add_to_archive         Adding COT/tests/input.iso to TAR file as input.iso
 VERBOSE: tar                    Added input.iso to temp.ova
    INFO: add_to_archive         Adding COT/tests/sample_cfg.txt to TAR file as sample_cfg.txt
 VERBOSE: tar                    Added sample_cfg.txt to temp.ova
```