### PR TITLE
Add up stacklevel

### DIFF
--- a/verboselogs/__init__.py
+++ b/verboselogs/__init__.py
@@ -148,19 +148,27 @@ class VerboseLogger(logging.Logger):
     def notice(self, msg, *args, **kw):
         """Log a message with level :data:`NOTICE`. The arguments are interpreted as for :func:`logging.debug()`."""
         if self.isEnabledFor(NOTICE):
+            kw.setdefault('stacklevel', 1)
+            kw['stacklevel'] += 1
             self._log(NOTICE, msg, args, **kw)
 
     def spam(self, msg, *args, **kw):
         """Log a message with level :data:`SPAM`. The arguments are interpreted as for :func:`logging.debug()`."""
         if self.isEnabledFor(SPAM):
+            kw.setdefault('stacklevel', 1)
+            kw['stacklevel'] += 1
             self._log(SPAM, msg, args, **kw)
 
     def success(self, msg, *args, **kw):
         """Log a message with level :data:`SUCCESS`. The arguments are interpreted as for :func:`logging.debug()`."""
         if self.isEnabledFor(SUCCESS):
+            kw.setdefault('stacklevel', 1)
+            kw['stacklevel'] += 1
             self._log(SUCCESS, msg, args, **kw)
 
     def verbose(self, msg, *args, **kw):
         """Log a message with level :data:`VERBOSE`. The arguments are interpreted as for :func:`logging.debug()`."""
         if self.isEnabledFor(VERBOSE):
+            kw.setdefault('stacklevel', 1)
+            kw['stacklevel'] += 1
             self._log(VERBOSE, msg, args, **kw)


### PR DESCRIPTION
When using `verboselogs`'s logging functions, the caller of `logging`'s log is actually `verboselogs` itself:

https://github.com/xolox/python-verboselogs/blob/3cebc69e03588bb6c3726c38c324b12732989292/verboselogs/__init__.py#L151

To make `logging` find the real caller, `stacklevel` should be added up by 1.

